### PR TITLE
Fixed queries being called to early

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -1,7 +1,6 @@
 local resource = GetCurrentResourceName()
 local config = json.decode(LoadResourceFile(resource, "config.json"))
 local authToken = nil
-local QueuedQueries = {}
 
 Citizen.CreateThread(function()
   if config.createtokenonstart then


### PR DESCRIPTION
This handles queries getting called too early, before the token is created, it now waits for the token to be created before calling the queries and sending the data back.