### PR TITLE
add ability for users to also use the server.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+#i IDE configuration
+.idea/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ and set the appropriate values.
 |    exsql_db_host    | string |   localhost   |
 |    exsql_db_user    | string |     root      |
 |  exsql_db_password  | string |               |
+|  exsql_db_database  | string |      drp      |
 |    exsql_devmode    | string |     false     |
 |  exsql_createtoken  | string |     true      |
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
+# Configuration
+
+Use either the config.json or server configruation to set your parameters. If you wish to use server configuration, simply delete the `config.json`
+and set the appropriate values.
+
+### Example config.json
+```json
+  "api": {
+    "host": "localhost",
+    "port": 2000,
+    "route": "/external/api",
+    "secret": "yoursecretkey",
+    "community": "testing"
+  },
+  "database": {
+    "connectionLimit": 100,
+    "host": "localhost",
+    "port": 3306,
+    "user": "root",
+    "password": "",
+    "database": "testing"
+  },
+  "devmodeactive": false,
+  "createtokenonstart": true
+```
+
+### List of server configuration variables
+---
+
+|    Variable Name    |  Type  |    Default    |
+| :-----------------: | :----: | :-----------: |
+|   exsql_api_host    | string |   localhost   |
+|   exsql_api_port    | number |     2000      |
+|   exsql_api_route   | string | /external/api |
+|  exsql_api_secret   | string | yoursecretkey |
+| exsql_api_community | string |    testing    |
+|    exsql_db_host    | string |   localhost   |
+|    exsql_db_user    | string |     root      |
+|  exsql_db_password  | string |               |
+|    exsql_devmode    | string |     false     |
+|  exsql_createtoken  | string |     true      |
+
+### Example server.cfg
+
+```
+... other config
+
+set exsql_db_host "my.db.host"
+set exsql_db_user "mydbuser"
+set exsql_db_password "mydbpass"
+```
+
+
+
 # LICENSE
 
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,184 @@
+const sv_configKeys = {
+    exsql_api_host: {
+        name: "api.host",
+        type: "string",
+        default: "localhost"
+    },
+    exsql_api_port: {
+        name: "api.port",
+        type: "number",
+        default: 2000
+    },
+    exsql_api_route: {
+        name: "api.route",
+        type: "string",
+        default: "/external/api"
+    },
+    exsql_api_secret: {
+        name: "api.secret",
+        type: "string",
+        default: "yoursecretkey"
+    },
+    exsql_api_community: {
+        name: "api.community",
+        type: "string",
+        default: "testing"
+    },
+    exsql_db_connectionLimit: {
+        name: "database.connectionLimit",
+        type: "number",
+        default: 100
+    },
+    exsql_db_host: {
+        name: "database.host",
+        type: "string",
+        default: "localhost"
+    },
+    exsql_db_port: {
+        name: "database.port",
+        type: "number",
+        default: 3306
+    },
+    exsql_db_user: {
+        name: "database.user",
+        type: "string",
+        default: "root"
+    },
+    exsql_db_password: {
+        name: "database.password",
+        type: "string",
+        default: ""
+    },
+    exsql_devmode: {
+        name: "devmodeactive",
+        type: "boolean",
+        default: false
+    },
+    exsql_createtoken: {
+        name: "createtokenonstart",
+        type: "boolean",
+        default: true
+    }
+};
+
+const regex = /(\w+).?(\w+)?/gm;
+
+const config = {
+    data: {
+        api: {
+            host: "",
+            port: 0,
+            route: "",
+            secret: "",
+            community: ""
+        },
+        database: {
+            connectionLimit: 0,
+            host: "",
+            port: 0,
+            user: "",
+            password: "",
+            database: ""
+        },
+        devmodeactive: false,
+        createtokenonstart: true
+    },
+    load() {
+        let config = {};
+        const configString = LoadResourceFile(GetCurrentResourceName(), "config.json");
+        if(configString === "" || !configString) {
+            console.log(`^3[${GetCurrentResourceName()}]^7: ^4config.json not detected, loading from server config^7`);
+            for(const [key, info] of Object.entries(sv_configKeys)) {
+                const defaultValue = typeof info.default === "boolean" ? info.default === true ? "true" : "false" : info.default;
+                const value = GetConvar(key, defaultValue);
+                try {
+                    const parsedValue = this.castType(info.type, value);
+                    this.setConfigValue(info.name, parsedValue);
+                } catch(e) {
+                    console.log(`^1[${GetCurrentResourceName()}]: ${e.message}^7`);
+                }
+            }
+        } else {
+            try {
+                config = JSON.parse(configString);
+                this.data = config;
+                console.log(`^2[${GetCurrentResourceName()}]^7:^2 successfully loaded config.json^7`);
+            } catch(e) {
+                console.log(`^1[${GetCurrentResourceName()}]^7: ^3failed to parse config.json. ${e.message}^7`);
+            }
+        }
+
+        setImmediate(() => {
+            emit('ExternalSQL:ConfigLoaded', this.data);
+        });
+    },
+    /**
+     *
+     * @param {string} key
+     * @param {any} value
+     */
+    setConfigValue(key, value) {
+        const results = key.matchAll(regex)
+        for(const match of results) {
+            const matched = [...match];
+            if(matched.length !== 3) {
+                continue;
+            }
+            if(matched[2] === undefined) {
+                const targetKey = matched[1];
+                this.data[targetKey] = value;
+                Object.defineProperty(this.data, targetKey, {
+                    configurable: true,
+                    enumerable: true,
+                    value,
+                    writable: true
+                });
+            } else {
+                const targetParent = matched[1];
+                const targetKey = matched[2];
+                this.data[targetParent][targetKey] = value;
+                if(!this.data[targetParent]) {
+                    Object.defineProperty(this.data, targetParent, {
+                        configurable: true,
+                        enumerable: true,
+                        value: {},
+                        writable: true
+                    });
+                }
+                Object.defineProperty(this.data[targetParent], targetKey, {
+                    configurable: true,
+                    enumerable: true,
+                    value,
+                    writable: true
+                });
+            }
+        }
+    },
+    /**
+     * 
+     * @param {string} type 
+     * @param {any[]} value 
+     */
+    castType(type, value) {
+        let tmpValue;
+        switch(type) {
+            case "string":
+                return String(value);
+            case "number":
+                tmpValue = Number(value);
+                if(isNaN(tmpValue)) {
+                    throw new Error(`failed to convert ${value} to a number`);
+                }
+                return tmpValue;
+            case "boolean":
+                if(value !== "true" && value !== "false") {
+                    throw new Error(`type specified for boolean must be either "true" or "false"`);
+                }
+                return value == "true";
+            default:
+                throw new Error(`no handler set for type ${type}`);
+        }
+    }
+}
+
+module.exports = config;

--- a/config.js
+++ b/config.js
@@ -49,6 +49,11 @@ const sv_configKeys = {
         type: "string",
         default: ""
     },
+    exsql_db_database: {
+        name: "database.database",
+        type: "string",
+        default: "drp"
+    },
     exsql_devmode: {
         name: "devmodeactive",
         type: "boolean",

--- a/database.js
+++ b/database.js
@@ -1,5 +1,6 @@
 const mysql = require("mysql");
-const config = require("./config.json");
+const configLoader = require("./config.js");
+const config = configLoader.data;
 const devmode = config.devmodeactive;
 
 const pool = mysql.createPool(config.database);

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,3 +6,7 @@ game { "gta5", "rdr3" }
 
 server_script "index.js"
 server_script "server.lua"
+
+files {
+    "config.json"
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 const express = require("express");
 const app = express();
 const bodyParser = require("body-parser");
-const config = require("./config.json");
+const configLoader = require("./config.js");
+
+configLoader.load();
+const config = configLoader.data;
 
 // APP USE BODYPARSER JSON
 app.use(bodyParser.json())
@@ -11,6 +14,7 @@ require("./routes")(app);
 
 // APP LISTENER
 app.listen(config.api.port, "localhost", (req, res) => {
+  emit('ExternalSQL:APIReady');
   console.log(`API Server Listening On Port: ${config.api.port}`)
 })
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ require("./routes")(app);
 
 // APP LISTENER
 app.listen(config.api.port, "localhost", (req, res) => {
-  emit('ExternalSQL:APIReady');
+  setImmediate(() => {
+    emit('ExternalSQL:APIReady');
+  })
   console.log(`API Server Listening On Port: ${config.api.port}`)
 })
 

--- a/routes.js
+++ b/routes.js
@@ -1,5 +1,6 @@
 const jwt = require("jsonwebtoken");
-const config = require("./config.json");
+const configLoader = require("./config.js")
+const config = configLoader.data
 const SendQuery = require("./database");
 
 module.exports = (app) => {

--- a/server.lua
+++ b/server.lua
@@ -1,13 +1,24 @@
-local resource = GetCurrentResourceName()
-local config = json.decode(LoadResourceFile(resource, "config.json"))
+local config = {}
 local authToken = nil
 local StoredQueries = {}
 
-AddEventHandler("onResourceStart", function(startingResource)
-  if resource == startingResource then
-    if config.createtokenonstart then
-      CreateToken()
-    end
+OnReadyQueue = {
+  CREATE_TOKEN = {
+      handler = function()
+          if config.createtokenonstart then
+            CreateToken()
+          end
+      end
+  }
+}
+
+AddEventHandler('ExternalSQL:ConfigLoaded', function (data)
+  config = data
+end)
+
+AddEventHandler('ExternalSQL:APIReady', function()
+  for k,v in pairs(OnReadyQueue) do
+      v.handler()
   end
 end)
 


### PR DESCRIPTION
Will allow users the option to use either the config.json or server.cfg. This is a change I'm mostly making for myself, but am opening the pr in case its something that may have been of interest to others. These changes are not breaking to the current configuration specifications.

The README has been updated accordingly. 

in `server.lua` the load/ready events have been changed to allow for more consistent (100% consistent) startup logic.

I would have just liked to use a mysql connection string for the server.cfg, but maybe at a later date.
